### PR TITLE
Add syntax highlighting for markdown documentation

### DIFF
--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -32,6 +32,7 @@ patterns:
 - include: '#serviceDec'
 - include: '#endpointDef'
 - include: '#documentationDef'
+- include: '#mdDocumentation'
 - include: '#typeDef'
 - include: '#objectDec'
 - include: '#record'
@@ -313,6 +314,41 @@ repository:
       - include: '#parameter'
       - include: '#matchStatementPatternClause'
       - include: '#comment'
+
+  mdDocumentation:
+    patterns:
+    - include: '#mdDocumentationReturnParamDescription'
+    - include: '#mdDocumentationParamDescription'
+    - match: '#.*'
+      name: comment.mddocs.ballerina
+
+  mdDocumentationParamDescription:
+    patterns:
+    - begin: '(#)(?: ?)(\+)(?: *)({{identifier}})?(?: *)(-)?(.*)'
+      beginCaptures:
+        '1': { name:  comment.mddocs.ballerina }
+        '2': { name:  keyword.ballerina }
+        '3': { name:  variable.parameter.ballerina }
+        '5': { name:  keyword.ballerina }
+        '6': { name:  comment.mddocs.paramdesc.ballerina }
+      end: '(?=[^#\r\n]|(?:# ?\+))'
+      patterns:
+      - match: '#.*'
+        name: comment.mddocs.paramdesc.ballerina
+
+  mdDocumentationReturnParamDescription:
+    patterns:
+    - begin: '(#)(?: ?)(\+)(?: *)(return)(?: *)(-)?(.*)'
+      beginCaptures:
+        '1': { name:  comment.mddocs.ballerina }
+        '2': { name:  keyword.ballerina }
+        '3': { name:  keyword.ballerina }
+        '4': { name:  keyword.ballerina }
+        '5': { name:  comment.mddocs.returnparamdesc.ballerina }
+      end: '(?=[^#\r\n]|(?:# ?\+))'
+      patterns:
+      - match: '#.*'
+        name: comment.mddocs.returnparamdesc.ballerina
 
   numbers:
     patterns:

--- a/syntaxes/ballerina.monarch.json
+++ b/syntaxes/ballerina.monarch.json
@@ -13,6 +13,9 @@
             "include": "documentationDef"
         },
         {
+            "include": "mdDocumentation"
+        },
+        {
             "include": "typeDef"
         },
         {
@@ -1225,6 +1228,74 @@
                 "next": "@pop",
                 "token": "variable.parameter.ballerina"
             }
+        ]
+    ],
+    "mdDocumentation": [
+        {
+            "include": "mdDocumentationReturnParamDescription"
+        },
+        {
+            "include": "mdDocumentationParamDescription"
+        },
+        [
+            "#.*",
+            "comment.mddocs.ballerina"
+        ]
+    ],
+    "mdDocumentationReturnParamDescription": [
+        [
+            "(#)(?: ?)(\\+)(?: *)(return)(?: *)(-)?(.*)",
+            [
+                {
+                    "next": "mdDocumentationReturnParamDescription__b__0",
+                    "token": "comment.mddocs.ballerina"
+                },
+                "keyword.ballerina",
+                "keyword.ballerina",
+                "keyword.ballerina",
+                "comment.mddocs.returnparamdesc.ballerina"
+            ]
+        ]
+    ],
+    "mdDocumentationReturnParamDescription__b__0": [
+        [
+            "(?=[^#\\r\\n]|(?:# ?\\+))",
+            {
+                "next": "@pop",
+                "token": ""
+            }
+        ],
+        [
+            "#.*",
+            "comment.mddocs.returnparamdesc.ballerina"
+        ]
+    ],
+    "mdDocumentationParamDescription": [
+        [
+            "(#)(?: ?)(\\+)(?: *)((?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))?(?: *)(-)?(.*)",
+            [
+                {
+                    "next": "mdDocumentationParamDescription__b__0",
+                    "token": "comment.mddocs.ballerina"
+                },
+                "keyword.ballerina",
+                "variable.parameter.ballerina",
+                "keyword.ballerina",
+                "comment.mddocs.paramdesc.ballerina"
+            ]
+        ]
+    ],
+    "mdDocumentationParamDescription__b__0": [
+        [
+            "(?=[^#\\r\\n]|(?:# ?\\+))",
+            {
+                "next": "@pop",
+                "token": ""
+            }
+        ],
+        [
+            "#.*",
+            "comment.mddocs.paramdesc.ballerina"
         ]
     ],
     "typeDef": [

--- a/syntaxes/ballerina.tmLanguage
+++ b/syntaxes/ballerina.tmLanguage
@@ -62,6 +62,10 @@
       </dict>
       <dict>
         <key>include</key>
+        <string>#mdDocumentation</string>
+      </dict>
+      <dict>
+        <key>include</key>
         <string>#typeDef</string>
       </dict>
       <dict>
@@ -935,6 +939,124 @@
               <dict>
                 <key>include</key>
                 <string>#comment</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>mdDocumentation</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#mdDocumentationReturnParamDescription</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#mdDocumentationParamDescription</string>
+          </dict>
+          <dict>
+            <key>match</key>
+            <string>#.*</string>
+            <key>name</key>
+            <string>comment.mddocs.ballerina</string>
+          </dict>
+        </array>
+      </dict>
+      <key>mdDocumentationParamDescription</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(#)(?: ?)(\+)(?: *)((?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\^"([^|"\\\f\n\r\t]|\\\\[btnfr]|\\[|"\\/])+"))?(?: *)(-)?(.*)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>comment.mddocs.ballerina</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>variable.parameter.ballerina</string>
+              </dict>
+              <key>5</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+              <key>6</key>
+              <dict>
+                <key>name</key>
+                <string>comment.mddocs.paramdesc.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?=[^#\r\n]|(?:# ?\+))</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>match</key>
+                <string>#.*</string>
+                <key>name</key>
+                <string>comment.mddocs.paramdesc.ballerina</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>mdDocumentationReturnParamDescription</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(#)(?: ?)(\+)(?: *)(return)(?: *)(-)?(.*)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>comment.mddocs.ballerina</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+              <key>4</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+              <key>5</key>
+              <dict>
+                <key>name</key>
+                <string>comment.mddocs.returnparamdesc.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?=[^#\r\n]|(?:# ?\+))</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>match</key>
+                <string>#.*</string>
+                <key>name</key>
+                <string>comment.mddocs.returnparamdesc.ballerina</string>
               </dict>
             </array>
           </dict>


### PR DESCRIPTION
This adds syntax highlighting for,
 * parameters
 * parameter descriptions
 * return parameters
 * return parameter descriptions

![image](https://user-images.githubusercontent.com/3872221/45356665-7fba8780-b5e1-11e8-9ddf-241f7cd5dca9.png)
