### PR TITLE
Fix "inclued" typo

### DIFF
--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -120,7 +120,7 @@ repository:
       patterns:
       - include: '#comment'
       - include: '#continuedType'
-      - inclued: '#constrainType'
+      - include: '#constrainType'
       - name: '{{typeScope}}'
         match: \b({{identifier}})\b
 
@@ -131,7 +131,7 @@ repository:
       patterns:
       - include: '#comment'
       - include: '#continuedType'
-      - inclued: '#constrainType'
+      - include: '#constrainType'
       - name: '{{typeScope}}'
         match: \b({{identifier}})\b
 


### PR DESCRIPTION
## Purpose

Fix a typo that would prevent certain parts of the grammar from highlighting sections of code.

👋 from the Linguist community.

If you're not already aware, this grammar is included in [GitHub Linguist](https://github.com/github/linguist) which is used for syntax highlighting Ballerina on GitHub.com.

I'm the primary GitHub maintainer and am in the process of creating a new Linguist release (which involved pulling the latest version of this repo) when I noticed that your grammar is producing errors that will likely affect the highlighting:

```
- [ ] repository `vendor/grammars/ballerina-grammar` (from https://github.com/ballerina-platform/ballerina-grammar) (2 errors)
    - [ ] Unknown keys in grammar: `source.ballerina` (in `syntaxes/ballerina.tmLanguage`) contains invalid keys (`Repository[continuedTupleType].Patterns[0].Patterns[2].inclued`, `Repository[constrainType].Patterns[0].Patterns[2].inclued`, `monarchVariables`, `tmlVariables`)
    - [ ] Grammar conversion failed. File `syntaxes/ballerina.monarch.json` failed to parse: Undeclared scope in grammar: `syntaxes/ballerina.monarch.json` has no scope name
```

This PR addresses the two clearly invalid keys that are invalid due to a typo:

- `Repository[continuedTupleType].Patterns[0].Patterns[2].inclued`
- `Repository[constrainType].Patterns[0].Patterns[2].inclued`

I'm not addressing the others are they appear to be specific to your build environment and aren't likely to affect the rendering of the grammar.

If you're quick with merging this PR, I can include the changes in the next release of Linguist.

_Rest of the template removed as it doesn't appear to be relevant_