### PR TITLE
Update build script to match keywords in monarch build

### DIFF
--- a/build-monarch.js
+++ b/build-monarch.js
@@ -41,20 +41,13 @@ delete grammar.monarchVariables;
 // We can't convert the keywords highlighting from the yaml file due to what seems
 // to be a bug in monaco. Its reported here. https://github.com/Microsoft/monaco-editor/issues/890
 // For now keywords entry is manually added.
-const exceptions = ['keywords', 'types', 'boolean'];
+const exceptions = [];
 const patterns = grammar.patterns;
 const monarch = {};
 convert(grammar, grammar.patterns, monarch, 'root');
 
-//Following is manually adding keywords
-monarch.code.push(['[a-z][\\w$]*', {
-    cases: {
-        '@controlKeywords': 'keyword.control',
-        '@otherKeywords': 'keyword',
-        '@typeKeywords': 'type',
-        '@default': 'identifier',
-    },
-}])
+// Following is manually adding keywords
+monarch.code.push(['[a-z][\\w$]*', 'identifier']);
 
 fs.writeFileSync(outFile, JSON.stringify(monarch, null, 4));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ballerina-grammar",
-  "version": "0.970.0-alpha1",
+  "version": "0.972.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "base64-js": {
@@ -31,8 +31,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "plist": {
@@ -41,9 +41,9 @@
       "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.3",
-        "xmlbuilder": "9.0.7",
-        "xmldom": "0.1.27"
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^9.0.7",
+        "xmldom": "0.1.x"
       }
     },
     "sprintf-js": {

--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -12,8 +12,8 @@ variables:
   identifierLiteralChar: ([^|"\\\f\n\r\t]|\\\\[btnfr]|\\[|"\\/])
 
 monarchVariables:
-  typeScope: 'type.ballerina'
-  annotationScope: 'type.ballerina'
+  typeScope: 'type'
+  annotationScope: 'type'
   numberScope: 'number'
   xmlTagAngle: 'tag'
   xmlAttribute: 'variable.parameter'
@@ -48,12 +48,13 @@ repository:
       name: '{{annotationScope}}'
 
   annotationDefinition:
-    begin: '\bannotation\b'
-    beginCaptures:
-      '0': { name:  keyword.ballerina }
-    end: ';'
     patterns:
-    - include: '#typeDescription'
+    - begin: '\bannotation\b'
+      beginCaptures:
+        '0': { name:  keyword.ballerina }
+      end: ';'
+      patterns:
+      - include: '#typeDescription'
 
   booleans:
     patterns:

--- a/syntaxes/ballerina.monarch.json
+++ b/syntaxes/ballerina.monarch.json
@@ -298,7 +298,7 @@
     "annotationAttachment": [
         [
             "@((?:(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\")):)?(?:(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))",
-            "type.ballerina"
+            "type"
         ]
     ],
     "functionDefinition": [
@@ -373,7 +373,7 @@
             "((?=record|object)|(?:(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\")))",
             {
                 "next": "parameter__b__0",
-                "token": "type.ballerina"
+                "token": "type"
             }
         ]
     ],
@@ -568,7 +568,7 @@
             "(?:(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))(?: |\\t)|(?=\\()",
             {
                 "next": "variableDef__b__0",
-                "token": "type.ballerina"
+                "token": "type"
             }
         ]
     ],
@@ -615,7 +615,7 @@
         },
         [
             "\\b((?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))\\b",
-            "type.ballerina"
+            "type"
         ]
     ],
     "constrainType": [
@@ -643,7 +643,7 @@
         },
         [
             "\\b((?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))\\b",
-            "type.ballerina"
+            "type"
         ]
     ],
     "code": [
@@ -661,6 +661,9 @@
         },
         {
             "include": "stringTemplate"
+        },
+        {
+            "include": "keywords"
         },
         {
             "include": "strings"
@@ -685,14 +688,7 @@
         },
         [
             "[a-z][\\w$]*",
-            {
-                "cases": {
-                    "@controlKeywords": "keyword.control",
-                    "@otherKeywords": "keyword",
-                    "@typeKeywords": "type",
-                    "@default": "identifier"
-                }
-            }
+            "identifier"
         ]
     ],
     "booleans": [
@@ -830,7 +826,7 @@
             "var",
             {
                 "next": "matchBindingPattern__b__0",
-                "token": "type.ballerina"
+                "token": "type"
             }
         ]
     ],
@@ -1199,6 +1195,49 @@
             "string"
         ]
     ],
+    "keywords": [
+        [
+            "\\b(if|else|iterator|try|catch|finally|fork|join|all|some|while|foreach|in|throw|return|returns|break|timeout|transaction|abort|retry|retries|continue|bind|with|typeof|enum|wait)\\b",
+            "keyword.control.ballerina"
+        ],
+        [
+            "\\b(import|version|public|private|attach|as|native|documentation|lock|new|record|limit|ascending|descending|check|checkpanic|start|done|untaint|onretry|oncommit|onabort|scope|compensate|compensation|primarykey|channel|abstract|extern|final|listener|remote|client|is|__init)\\b",
+            "keyword.other.ballerina"
+        ],
+        [
+            "\\b(forever|from|on|select|group|by|having|order|where|followed|insert|into|update|set|for|window|query)\\b",
+            "keyword.other.siddhi.ballerina"
+        ],
+        [
+            "\\b(annotation|package|type|connector|function|resource|service|action|worker|struct|transformer|object)\\b",
+            "keyword.other.ballerina"
+        ],
+        [
+            "\\b(const|true|false|reply|create|parameter)\\b",
+            "keyword.other.ballerina"
+        ],
+        [
+            "(!|%|\\+|\\-|~=|==|=|!=|<|>|&&|\\|\\||\\?:|\\.\\.\\.)",
+            "keyword.operator.ballerina"
+        ],
+        {
+            "include": "types"
+        }
+    ],
+    "types": [
+        [
+            "\\b(boolean|int|float|string|var|any|anydata|datatable|table|byte|future|typedesc)\\b",
+            "type"
+        ],
+        [
+            "\\b(map|exception|json|xml|xmlns|error)\\b",
+            "type"
+        ],
+        [
+            "\\b(stream|streamlet|aggregation)\\b",
+            "type"
+        ]
+    ],
     "paranthesised": [
         [
             "\\(",
@@ -1351,7 +1390,7 @@
         },
         [
             "(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\")",
-            "type.ballerina"
+            "type"
         ],
         {
             "include": "comment"
@@ -1466,10 +1505,26 @@
         },
         [
             "(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\")",
-            "type.ballerina"
+            "type"
         ]
     ],
     "annotationDefinition": [
+        [
+            "\\bannotation\\b",
+            {
+                "next": "annotationDefinition__b__0",
+                "token": "keyword.ballerina"
+            }
+        ]
+    ],
+    "annotationDefinition__b__0": [
+        [
+            ";",
+            {
+                "next": "@pop",
+                "token": ""
+            }
+        ],
         {
             "include": "typeDescription"
         }

--- a/syntaxes/ballerina.tmLanguage
+++ b/syntaxes/ballerina.tmLanguage
@@ -15,9 +15,9 @@
     <key>monarchVariables</key>
     <dict>
       <key>typeScope</key>
-      <string>type.ballerina</string>
+      <string>type</string>
       <key>annotationScope</key>
-      <string>type.ballerina</string>
+      <string>type</string>
       <key>numberScope</key>
       <string>number</string>
       <key>xmlTagAngle</key>
@@ -109,23 +109,28 @@
       </dict>
       <key>annotationDefinition</key>
       <dict>
-        <key>begin</key>
-        <string>\bannotation\b</string>
-        <key>beginCaptures</key>
-        <dict>
-          <key>0</key>
-          <dict>
-            <key>name</key>
-            <string>keyword.ballerina</string>
-          </dict>
-        </dict>
-        <key>end</key>
-        <string>;</string>
         <key>patterns</key>
         <array>
           <dict>
-            <key>include</key>
-            <string>#typeDescription</string>
+            <key>begin</key>
+            <string>\bannotation\b</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>;</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#typeDescription</string>
+              </dict>
+            </array>
           </dict>
         </array>
       </dict>


### PR DESCRIPTION
## Purpose
ballerina keywords was skipped by monarch grammar builder due to https://github.com/Microsoft/monaco-editor/issues/890.

This updates the build script with a workaround. we match any remaining words that are not matched by any rule by `/[a-z][\\w$]/` and highlight them as identifiers.