### PR TITLE
Update syntax highlighting for string template variables

### DIFF
--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -323,8 +323,8 @@ repository:
         '1': { name:  comment.mddocs.ballerina }
         '2': { name:  keyword.ballerina }
         '3': { name:  variable.parameter.ballerina }
-        '5': { name:  keyword.ballerina }
-        '6': { name:  comment.mddocs.paramdesc.ballerina }
+        '4': { name:  keyword.ballerina }
+        '5': { name:  comment.mddocs.paramdesc.ballerina }
       end: '(?=[^#\r\n]|(?:# ?\+))'
       patterns:
       - match: '#.*'

--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -734,10 +734,10 @@ repository:
 
   templateVariable:
     patterns:
-    - begin: '{{'
+    - begin: '\${'
       beginCaptures:
         '0': { name: 'constant.character.escape.ballerina'}
-      end: '}}'
+      end: '}'
       endCaptures:
         '0': { name: 'constant.character.escape.ballerina'}
       patterns:

--- a/syntaxes/ballerina.monarch.json
+++ b/syntaxes/ballerina.monarch.json
@@ -1172,7 +1172,7 @@
     ],
     "templateVariable": [
         [
-            "{{",
+            "\\${",
             {
                 "next": "templateVariable__b__0",
                 "token": "constant.character.escape.ballerina"
@@ -1181,7 +1181,7 @@
     ],
     "templateVariable__b__0": [
         [
-            "}}",
+            "}",
             {
                 "next": "@pop",
                 "token": "constant.character.escape.ballerina"

--- a/syntaxes/ballerina.tmLanguage
+++ b/syntaxes/ballerina.tmLanguage
@@ -2272,7 +2272,7 @@
         <array>
           <dict>
             <key>begin</key>
-            <string>{{</string>
+            <string>\${</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -2282,7 +2282,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>}}</string>
+            <string>}</string>
             <key>endCaptures</key>
             <dict>
               <key>0</key>

--- a/syntaxes/ballerina.tmLanguage
+++ b/syntaxes/ballerina.tmLanguage
@@ -963,12 +963,12 @@
                 <key>name</key>
                 <string>variable.parameter.ballerina</string>
               </dict>
-              <key>5</key>
+              <key>4</key>
               <dict>
                 <key>name</key>
                 <string>keyword.ballerina</string>
               </dict>
-              <key>6</key>
+              <key>5</key>
               <dict>
                 <key>name</key>
                 <string>comment.mddocs.paramdesc.ballerina</string>


### PR DESCRIPTION
Fixes syntax highlighting for code within `${ }`
<img width="556" alt="image" src="https://user-images.githubusercontent.com/3872221/63214618-2aafbb80-c138-11e9-86b6-d2f3b303eed9.png">

Fixes ballerina-platform/ballerina-lang#17739
<img width="583" alt="image" src="https://user-images.githubusercontent.com/3872221/63215073-a280e480-c13e-11e9-8fb8-afaa1517105a.png">
