### PR TITLE
Add string template highlighting for prism

### DIFF
--- a/prism/prism-ballerina.js
+++ b/prism/prism-ballerina.js
@@ -1,7 +1,7 @@
 Prism.languages.ballerina = {
     'comment': /\/\/[^\r\n]*/,
     'string': {
-        pattern: /"(?:[^\\"]|\\.)*(?:"|$)/,
+        pattern: /("(?:[^\\"]|\\.)*(?:"|$)|(`(?:[^\\`])*(?:`)))/,
         greedy: true,
     },
     'boolean': /\b(?:true|false)\b/,


### PR DESCRIPTION
## Purpose
Add string template highlighting for prism, which is used in the Ballerina website.

Fix https://github.com/ballerina-platform/ballerina-dev-website/issues/2038