### PR TITLE
Add regexp template grammar

### DIFF
--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -1741,6 +1741,7 @@ repository:
       endCaptures:
         '1': { name: punctuation.definition.regexp.template.end.ballerina }
       patterns:
+      - include: '#template-substitution-element'
       - include: '#regexp'
 
   regexp:
@@ -1759,6 +1760,7 @@ repository:
       endCaptures:
         '1': { name: punctuation.definition.group.regexp.ballerina }
       patterns:
+      - include: '#template-substitution-element'
       - include: '#regexp'
       - include: '#flags-on-off'
       - include: '#unicode-property-escape'
@@ -1781,10 +1783,11 @@ repository:
       - include: '#regex-character-class'
       - include: '#unicode-values'
       - include: '#unicode-property-escape'
+    - include: '#template-substitution-element'
     - include: '#regex-character-class'
     - include: '#unicode-values'
     - include: '#unicode-property-escape'
-
+    
   regex-character-class:
     patterns:
     - name: keyword.other.character-class.regexp.ballerina
@@ -1851,3 +1854,4 @@ repository:
       name: constant.other.flag.regexp.ballerina
       patterns:
       - include: '#regexp'
+      - include: '#template-substitution-element'

--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -1725,7 +1725,6 @@ repository:
     - include: '#paranthesisedBracket'
     - include: '#regex'
 
-
   type-primitive:
     patterns:
     - match: '{{startOfIdentifier}}{{primitiveTypes}}{{endOfIdentifier}}'
@@ -1852,4 +1851,3 @@ repository:
       name: constant.other.flag.regexp.ballerina
       patterns:
       - include: '#regexp'
-      

--- a/syntaxes/ballerina.YAML-tmLanguage
+++ b/syntaxes/ballerina.YAML-tmLanguage
@@ -134,6 +134,7 @@ repository:
     - include: '#mdDocumentation'
     - include: '#keywords'
     - include: '#annotationAttachment'
+    - include: '#regex'
 
   declaration:
     patterns:
@@ -165,6 +166,7 @@ repository:
     - include: '#keywords'
     - include: '#expressionWithoutIdentifiers'
     - include: '#identifiers'
+    - include: '#regex'
 
   expressionWithoutIdentifiers:
     patterns: 
@@ -177,6 +179,7 @@ repository:
     - include: '#expression-operators'
     - include: '#literal'
     - include: '#paranthesised'
+    - include: '#regex'
 
   object-literal:
     name: meta.objectliteral.ballerina
@@ -649,6 +652,7 @@ repository:
     - include: '#functionParameters'
     - include: '#punctuation-semicolon'
     - include: '#function-body'
+    - include: '#regex'
 
   functionName:
     patterns:
@@ -688,6 +692,7 @@ repository:
     - include: '#array-literal'
     - include: '#variable-initializer'
     - include: '#identifiers'
+    - include: '#regex'
     - name: punctuation.separator.parameter.ballerina
       match: \,
 
@@ -828,6 +833,7 @@ repository:
         - include: '#expression-operators'
         - include: '#literal'
         - include: '#paranthesised'
+        - include: '#regex'
       - begin: '(?<=\))(?=\s|\=)'
         end: (?=\{)
         patterns:  
@@ -1058,6 +1064,7 @@ repository:
     - include: '#parameter-name'
     - include: '#variable-initializer'
     - include: '#expression'
+    - include: '#regex'
 
   paranthesisedBracket:
     patterns:
@@ -1245,6 +1252,7 @@ repository:
       - include: '#type-annotation'
       - include: '#keywords'
       - include: '#type-tuple'
+      - include: '#regex'
     - include: '#punctuation-comma'
     # const
     - name: meta.var.expr.ballerina
@@ -1287,6 +1295,7 @@ repository:
       - include: '#type-annotation'
       - include: '#keywords'
       - include: '#type-tuple'
+      - include: '#regex'
     - include: '#punctuation-comma'
 
   var-single-variable:
@@ -1340,6 +1349,7 @@ repository:
       - include: '#function-defn'
       - include: '#expression'
       - include: '#punctuation-accessor'
+      - include: '#regex'
     - begin: (?<!=|!)(=)(?!=|>)
       beginCaptures:
         '1': { name: keyword.operator.assignment.ballerina }
@@ -1592,6 +1602,7 @@ repository:
       patterns:
       - include: '#booleans'
       - include: '#stringTemplate'
+      - include: '#regex'
       - include: '#self-literal'
       - include: '#xml'
       - include: '#call' 
@@ -1712,8 +1723,133 @@ repository:
     - include: '#maps'
     - include: '#paranthesised'
     - include: '#paranthesisedBracket'
+    - include: '#regex'
+
 
   type-primitive:
     patterns:
     - match: '{{startOfIdentifier}}{{primitiveTypes}}{{endOfIdentifier}}'
       name: '{{primitiveScope}}'
+
+  regex:
+    patterns:
+    - begin: '(\bre)(\s*)(`)'
+      name: regexp.template.ballerina
+      beginCaptures:
+        '1': { name: '{{primitiveScope}}' }
+        '3': { name: punctuation.definition.regexp.template.begin.ballerina }
+      end: '`'
+      endCaptures:
+        '1': { name: punctuation.definition.regexp.template.end.ballerina }
+      patterns:
+      - include: '#regexp'
+
+  regexp:
+    patterns:
+    - name: keyword.control.assertion.regexp.ballerina
+      match: \^|\$
+    - name: keyword.operator.quantifier.regexp.ballerina
+      match: '[?+*]|\{(\d+,\d+|\d+,|,\d+|\d+)\}\??'
+    - name: keyword.operator.or.regexp.ballerina
+      match: \|
+    - name: meta.group.assertion.regexp.ballerina
+      begin: (\()
+      beginCaptures:
+        '1': { name: punctuation.definition.group.regexp.ballerina }
+      end: (\))
+      endCaptures:
+        '1': { name: punctuation.definition.group.regexp.ballerina }
+      patterns:
+      - include: '#regexp'
+      - include: '#flags-on-off'
+      - include: '#unicode-property-escape'
+    - name: constant.other.character-class.set.regexp.ballerina
+      begin: (\[)(\^)?
+      beginCaptures:
+        '1': { name: punctuation.definition.character-class.start.regexp.ballerina }
+        '2': { name: keyword.operator.negation.regexp.ballerina }
+      end: (\])
+      endCaptures:
+        '1': { name: punctuation.definition.character-class.end.regexp.ballerina }
+      patterns:
+      - name: constant.other.character-class.range.regexp.ballerina
+        match: (?:.|(\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\[^pPu]))\-(?:[^\]\\]|(\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\[^pPu]))
+        captures:
+          '1': { name: constant.character.numeric.regexp }
+          '2': { name: constant.character.escape.backslash.regexp }
+          '3': { name: constant.character.numeric.regexp }
+          '4': { name: constant.character.escape.backslash.regexp }
+      - include: '#regex-character-class'
+      - include: '#unicode-values'
+      - include: '#unicode-property-escape'
+    - include: '#regex-character-class'
+    - include: '#unicode-values'
+    - include: '#unicode-property-escape'
+
+  regex-character-class:
+    patterns:
+    - name: keyword.other.character-class.regexp.ballerina
+      match: \\[wWsSdDtrn]|\.
+    - name: constant.character.escape.backslash.regexp
+      match: \\[^pPu]
+
+  unicode-property-escape:
+    patterns:
+    - name: keyword.other.unicode-property.regexp.ballerina
+      begin: (\\p|\\P)(\{)
+      beginCaptures:
+        '1': { name: keyword.other.unicode-property.regexp.ballerina }
+        '2': { name: punctuation.other.unicode-property.begin.regexp.ballerina }
+      end: (\})
+      endCaptures:
+        '1': { name: punctuation.other.unicode-property.end.regexp.ballerina }
+        patterns:
+        - include: '#regex-unicode-properties-general-category'
+        - include: '#regex-unicode-property-key'
+
+  regex-unicode-property-key:
+    patterns:
+    - name: keyword.other.unicode-property-key.regexp.ballerina
+      begin: (sc=|gc=)
+      beginCaptures:
+        '1': { name: keyword.other.unicode-property-key.regexp.ballerina }
+      end: ()
+      endCaptures:
+        '1': { name: punctuation.other.unicode-property.end.regexp.ballerina }
+        patterns:
+        - include: '#regex-unicode-properties-general-category'
+
+  regex-unicode-properties-general-category:
+    patterns:
+    - match: (Lu|Ll|Lt|Lm|Lo|L|Mn|Mc|Me|M|Nd|Nl|No|N|Pc|Pd|Ps|Pe|Pi|Pf|Po|P|Sm|Sc|Sk|So|S|Zs|Zl|Zp|Z|Cf|Cc|Cn|Co|C)
+      name: constant.other.unicode-property-general-category.regexp.ballerina    
+
+  unicode-values:
+    patterns:
+    - name: keyword.other.unicode-value.ballerina
+      begin: (\\u)(\{)
+      beginCaptures:
+        '1': { name: keyword.other.unicode-value.regexp.ballerina }
+        '2': { name: punctuation.other.unicode-value.begin.regexp.ballerina }
+      end: (\})
+      endCaptures:
+        '1': { name: punctuation.other.unicode-value.end.regexp.ballerina }
+        patterns:
+        - match: ([0-9A-Fa-f]{1,6})
+          name: constant.other.unicode-value.regexp.ballerina
+
+  flags-on-off:
+    name: meta.flags.regexp.ballerina
+    patterns:
+    - begin: (\??)([imsx]*)(-?)([imsx]*)(:)
+      beginCaptures:
+        '1': { name: punctuation.other.non-capturing-group-begin.regexp.ballerina }
+        '2': { name: keyword.other.non-capturing-group.flags-on.regexp.ballerina }
+        '3': { name: punctuation.other.non-capturing-group.off.regexp.ballerina }
+        '4': { name: keyword.other.non-capturing-group.flags-off.regexp.ballerina }
+        '5': { name: punctuation.other.non-capturing-group-end.regexp.ballerina }
+      end: ()
+      name: constant.other.flag.regexp.ballerina
+      patterns:
+      - include: '#regexp'
+      

--- a/syntaxes/ballerina.tmLanguage
+++ b/syntaxes/ballerina.tmLanguage
@@ -5318,6 +5318,10 @@
             <array>
               <dict>
                 <key>include</key>
+                <string>#template-substitution-element</string>
+              </dict>
+              <dict>
+                <key>include</key>
                 <string>#regexp</string>
               </dict>
             </array>
@@ -5371,6 +5375,10 @@
             </dict>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>include</key>
+                <string>#template-substitution-element</string>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>#regexp</string>
@@ -5457,6 +5465,10 @@
                 <string>#unicode-property-escape</string>
               </dict>
             </array>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#template-substitution-element</string>
           </dict>
           <dict>
             <key>include</key>
@@ -5675,6 +5687,10 @@
               <dict>
                 <key>include</key>
                 <string>#regexp</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#template-substitution-element</string>
               </dict>
             </array>
           </dict>

--- a/syntaxes/ballerina.tmLanguage
+++ b/syntaxes/ballerina.tmLanguage
@@ -103,6 +103,10 @@
             <key>include</key>
             <string>#annotationAttachment</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex</string>
+          </dict>
         </array>
       </dict>
       <key>declaration</key>
@@ -204,6 +208,10 @@
             <key>include</key>
             <string>#identifiers</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex</string>
+          </dict>
         </array>
       </dict>
       <key>expressionWithoutIdentifiers</key>
@@ -245,6 +253,10 @@
           <dict>
             <key>include</key>
             <string>#paranthesised</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex</string>
           </dict>
         </array>
       </dict>
@@ -1802,6 +1814,10 @@
             <key>include</key>
             <string>#function-body</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex</string>
+          </dict>
         </array>
       </dict>
       <key>functionName</key>
@@ -1935,6 +1951,10 @@
           <dict>
             <key>include</key>
             <string>#identifiers</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex</string>
           </dict>
           <dict>
             <key>name</key>
@@ -2410,6 +2430,10 @@
                   <dict>
                     <key>include</key>
                     <string>#paranthesised</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#regex</string>
                   </dict>
                 </array>
               </dict>
@@ -3148,6 +3172,10 @@
             <key>include</key>
             <string>#expression</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex</string>
+          </dict>
         </array>
       </dict>
       <key>paranthesisedBracket</key>
@@ -3730,6 +3758,10 @@
                 <key>include</key>
                 <string>#type-tuple</string>
               </dict>
+              <dict>
+                <key>include</key>
+                <string>#regex</string>
+              </dict>
             </array>
           </dict>
           <dict>
@@ -3873,6 +3905,10 @@
               <dict>
                 <key>include</key>
                 <string>#type-tuple</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#regex</string>
               </dict>
             </array>
           </dict>
@@ -4052,6 +4088,10 @@
               <dict>
                 <key>include</key>
                 <string>#punctuation-accessor</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#regex</string>
               </dict>
             </array>
           </dict>
@@ -4829,6 +4869,10 @@
               </dict>
               <dict>
                 <key>include</key>
+                <string>#regex</string>
+              </dict>
+              <dict>
+                <key>include</key>
                 <string>#self-literal</string>
               </dict>
               <dict>
@@ -5220,6 +5264,10 @@
             <key>include</key>
             <string>#paranthesisedBracket</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex</string>
+          </dict>
         </array>
       </dict>
       <key>type-primitive</key>
@@ -5231,6 +5279,404 @@
             <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(string|int|boolean|float|byte|decimal|json|xml|anydata)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
             <key>name</key>
             <string>support.type.primitive.ballerina</string>
+          </dict>
+        </array>
+      </dict>
+      <key>regex</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(\bre)(\s*)(`)</string>
+            <key>name</key>
+            <string>regexp.template.ballerina</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>support.type.primitive.ballerina</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.regexp.template.begin.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>`</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.regexp.template.end.ballerina</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#regexp</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>regexp</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.assertion.regexp.ballerina</string>
+            <key>match</key>
+            <string>\^|\$</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>keyword.operator.quantifier.regexp.ballerina</string>
+            <key>match</key>
+            <string>[?+*]|\{(\d+,\d+|\d+,|,\d+|\d+)\}\??</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>keyword.operator.or.regexp.ballerina</string>
+            <key>match</key>
+            <string>\|</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>meta.group.assertion.regexp.ballerina</string>
+            <key>begin</key>
+            <string>(\()</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.group.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(\))</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.group.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#regexp</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#flags-on-off</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#unicode-property-escape</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>constant.other.character-class.set.regexp.ballerina</string>
+            <key>begin</key>
+            <string>(\[)(\^)?</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.character-class.start.regexp.ballerina</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.operator.negation.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(\])</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.character-class.end.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>name</key>
+                <string>constant.other.character-class.range.regexp.ballerina</string>
+                <key>match</key>
+                <string>(?:.|(\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\[^pPu]))\-(?:[^\]\\]|(\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\[^pPu]))</string>
+                <key>captures</key>
+                <dict>
+                  <key>1</key>
+                  <dict>
+                    <key>name</key>
+                    <string>constant.character.numeric.regexp</string>
+                  </dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>constant.character.escape.backslash.regexp</string>
+                  </dict>
+                  <key>3</key>
+                  <dict>
+                    <key>name</key>
+                    <string>constant.character.numeric.regexp</string>
+                  </dict>
+                  <key>4</key>
+                  <dict>
+                    <key>name</key>
+                    <string>constant.character.escape.backslash.regexp</string>
+                  </dict>
+                </dict>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#regex-character-class</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#unicode-values</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#unicode-property-escape</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#regex-character-class</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#unicode-values</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#unicode-property-escape</string>
+          </dict>
+        </array>
+      </dict>
+      <key>regex-character-class</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>keyword.other.character-class.regexp.ballerina</string>
+            <key>match</key>
+            <string>\\[wWsSdDtrn]|\.</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>constant.character.escape.backslash.regexp</string>
+            <key>match</key>
+            <string>\\[^pPu]</string>
+          </dict>
+        </array>
+      </dict>
+      <key>unicode-property-escape</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>keyword.other.unicode-property.regexp.ballerina</string>
+            <key>begin</key>
+            <string>(\\p|\\P)(\{)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.unicode-property.regexp.ballerina</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.unicode-property.begin.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(\})</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.unicode-property.end.regexp.ballerina</string>
+              </dict>
+              <key>patterns</key>
+              <array>
+                <dict>
+                  <key>include</key>
+                  <string>#regex-unicode-properties-general-category</string>
+                </dict>
+                <dict>
+                  <key>include</key>
+                  <string>#regex-unicode-property-key</string>
+                </dict>
+              </array>
+            </dict>
+          </dict>
+        </array>
+      </dict>
+      <key>regex-unicode-property-key</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>keyword.other.unicode-property-key.regexp.ballerina</string>
+            <key>begin</key>
+            <string>(sc=|gc=)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.unicode-property-key.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>()</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.unicode-property.end.regexp.ballerina</string>
+              </dict>
+              <key>patterns</key>
+              <array>
+                <dict>
+                  <key>include</key>
+                  <string>#regex-unicode-properties-general-category</string>
+                </dict>
+              </array>
+            </dict>
+          </dict>
+        </array>
+      </dict>
+      <key>regex-unicode-properties-general-category</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>match</key>
+            <string>(Lu|Ll|Lt|Lm|Lo|L|Mn|Mc|Me|M|Nd|Nl|No|N|Pc|Pd|Ps|Pe|Pi|Pf|Po|P|Sm|Sc|Sk|So|S|Zs|Zl|Zp|Z|Cf|Cc|Cn|Co|C)</string>
+            <key>name</key>
+            <string>constant.other.unicode-property-general-category.regexp.ballerina</string>
+          </dict>
+        </array>
+      </dict>
+      <key>unicode-values</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>keyword.other.unicode-value.ballerina</string>
+            <key>begin</key>
+            <string>(\\u)(\{)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.unicode-value.regexp.ballerina</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.unicode-value.begin.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(\})</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.unicode-value.end.regexp.ballerina</string>
+              </dict>
+              <key>patterns</key>
+              <array>
+                <dict>
+                  <key>match</key>
+                  <string>([0-9A-Fa-f]{1,6})</string>
+                  <key>name</key>
+                  <string>constant.other.unicode-value.regexp.ballerina</string>
+                </dict>
+              </array>
+            </dict>
+          </dict>
+        </array>
+      </dict>
+      <key>flags-on-off</key>
+      <dict>
+        <key>name</key>
+        <string>meta.flags.regexp.ballerina</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(\??)([imsx]*)(-?)([imsx]*)(:)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.non-capturing-group-begin.regexp.ballerina</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.non-capturing-group.flags-on.regexp.ballerina</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.non-capturing-group.off.regexp.ballerina</string>
+              </dict>
+              <key>4</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.non-capturing-group.flags-off.regexp.ballerina</string>
+              </dict>
+              <key>5</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.other.non-capturing-group-end.regexp.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>()</string>
+            <key>name</key>
+            <string>constant.other.flag.regexp.ballerina</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#regexp</string>
+              </dict>
+            </array>
           </dict>
         </array>
       </dict>

--- a/test/resources/config/regexp.bal
+++ b/test/resources/config/regexp.bal
@@ -1,0 +1,24 @@
+function name() {
+
+    string pattern = "ABC";
+    
+    string:RegExp _ = re `abc`;
+    string:RegExp _ = re `(abc)`;
+    string:RegExp _ = re `[abc]`;
+
+    string:RegExp _ = re `\p{gc=Ll}|\P{Lm}|\p{sc=Latin}`;
+    string:RegExp _ = re `\u{12FFFF}`;
+
+    string:RegExp _ = re `${pattern}`;
+    string:RegExp _ = re `\w\s\n`;
+
+    string:RegExp _ = re `(?-:abc)`;
+    string:RegExp _ = re `(?i-:abc)`;
+    string:RegExp _ = re `(?im-sx:abc)`;
+
+    string:RegExp _ = re `(abc)|${pattern}|[abc]|(?i:abc)`;
+    string:RegExp _ = re `[((abc))))\]]`;
+
+    string:RegExp _ = re `[abc\w\p{Ll}\u{FF}]`;
+
+}

--- a/test/resources/config/regexp.bal
+++ b/test/resources/config/regexp.bal
@@ -18,7 +18,6 @@ function name() {
     string:RegExp _ = re `\p{gc=Ll}|\P{Lm}|\p{sc=Latin}`;
     string:RegExp _ = re `\u{12FFFF}`;
 
-    string:RegExp _ = re `${pattern}`;
     string:RegExp _ = re `\w\s\n`;
 
     string:RegExp _ = re `(?-:abc)`;
@@ -31,9 +30,15 @@ function name() {
     string:RegExp _ = re `[abc\w\p{Ll}\u{FF}]`;
     string:RegExp _ = re `[a-z\w]`;
 
+    string:RegExp _ = re `${pattern}`;
     string:RegExp _ = re `${myFunction()}`;
+    string:RegExp _ = re `${"ABC"}`;
+    string:RegExp _ = re `(?:${pattern})`;
+    string:RegExp _ = re `(${myFunction()})`;
+    string:RegExp _ = re `[(${"ABC"})]|[${"ABC"}]`;
+
 }
 
-function myFunction() retunrns string {
+function myFunction() returns string {
     return "abc";
 }

--- a/test/resources/config/regexp.bal
+++ b/test/resources/config/regexp.bal
@@ -1,3 +1,12 @@
+
+string str = "pattern";
+type MyRecord record {
+   string myStr = "aaa";
+};
+
+MyRecord rA = { myStr: "abc" };
+string:RegExp _ = re `(abc)|${str}|[abc-f\d\-]|(?i:abc)|\p{Ll}|${rA.myStr}`;
+
 function name() {
 
     string pattern = "ABC";
@@ -20,5 +29,11 @@ function name() {
     string:RegExp _ = re `[((abc))))\]]`;
 
     string:RegExp _ = re `[abc\w\p{Ll}\u{FF}]`;
+    string:RegExp _ = re `[a-z\w]`;
 
+    string:RegExp _ = re `${myFunction()}`;
+}
+
+function myFunction() retunrns string {
+    return "abc";
 }

--- a/test/resources/snapshots/regexp.bal.snap
+++ b/test/resources/snapshots/regexp.bal.snap
@@ -1,0 +1,311 @@
+// SYNTAX TEST "source.ballerina" "regexp template highlighting testcase"
+
+>function name() {
+#^^^^^^^^ source.ballerina meta.function.ballerina keyword.other.ballerina
+#        ^ source.ballerina meta.function.ballerina
+#         ^^^^ source.ballerina meta.function.ballerina meta.definition.function.ballerina entity.name.function.ballerina
+#             ^ source.ballerina meta.function.ballerina meta.parameters.ballerina punctuation.definition.parameters.begin.ballerina
+#              ^ source.ballerina meta.function.ballerina meta.parameters.ballerina punctuation.definition.parameters.end.ballerina
+#               ^ source.ballerina meta.function.ballerina
+#                ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+>
+>    string pattern = "ABC";
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#           ^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.var-single-variable.expr.ballerina meta.definition.variable.ballerina variable.other.readwrite.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.var-single-variable.expr.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina string.quoted.double.ballerina punctuation.definition.string.begin.ballerina
+#                      ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina string.quoted.double.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina string.quoted.double.ballerina punctuation.definition.string.end.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    
+>    string:RegExp _ = re `abc`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                             ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                              ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `(abc)`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                              ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                               ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `[abc]`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                           ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
+#                              ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                               ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>
+>    string:RegExp _ = re `\p{gc=Ll}|\P{Lm}|\p{sc=Latin}`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina keyword.other.unicode-property.regexp.ballerina
+#                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.begin.regexp.ballerina
+#                             ^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.end.regexp.ballerina
+#                                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                    ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.begin.regexp.ballerina
+#                                       ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.end.regexp.ballerina
+#                                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                           ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                             ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.begin.regexp.ballerina
+#                                              ^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.end.regexp.ballerina
+#                                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `\u{12FFFF}`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-value.ballerina keyword.other.unicode-value.regexp.ballerina
+#                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-value.ballerina punctuation.other.unicode-value.begin.regexp.ballerina
+#                             ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-value.ballerina
+#                                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-value.ballerina punctuation.other.unicode-value.end.regexp.ballerina
+#                                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>
+>    string:RegExp _ = re `${pattern}`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
+#                           ^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `\w\s\n`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.character-class.regexp.ballerina
+#                            ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.character-class.regexp.ballerina
+#                              ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.character-class.regexp.ballerina
+#                                ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>
+>    string:RegExp _ = re `(?-:abc)`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina keyword.operator.quantifier.regexp.ballerina
+#                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group.off.regexp.ballerina
+#                             ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group-end.regexp.ballerina
+#                              ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                   ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `(?i-:abc)`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina keyword.operator.quantifier.regexp.ballerina
+#                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina keyword.other.non-capturing-group.flags-on.regexp.ballerina
+#                             ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group.off.regexp.ballerina
+#                              ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group-end.regexp.ballerina
+#                               ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                    ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `(?im-sx:abc)`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina keyword.operator.quantifier.regexp.ballerina
+#                            ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina keyword.other.non-capturing-group.flags-on.regexp.ballerina
+#                              ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group.off.regexp.ballerina
+#                               ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina keyword.other.non-capturing-group.flags-off.regexp.ballerina
+#                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group-end.regexp.ballerina
+#                                  ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>
+>    string:RegExp _ = re `(abc)|${pattern}|[abc]|(?i:abc)`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                              ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                               ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
+#                                 ^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                                            ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
+#                                               ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                                                ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina keyword.operator.quantifier.regexp.ballerina
+#                                                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina keyword.other.non-capturing-group.flags-on.regexp.ballerina
+#                                                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group-end.regexp.ballerina
+#                                                     ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                                          ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `[((abc))))\]]`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                           ^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
+#                                    ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina constant.character.escape.backslash.regexp
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>
+>    string:RegExp _ = re `[abc\w\p{Ll}\u{FF}]`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                           ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
+#                              ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.character-class.regexp.ballerina
+#                                ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-property.regexp.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.begin.regexp.ballerina
+#                                   ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.end.regexp.ballerina
+#                                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-value.ballerina keyword.other.unicode-value.regexp.ballerina
+#                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-value.ballerina punctuation.other.unicode-value.begin.regexp.ballerina
+#                                         ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-value.ballerina
+#                                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.unicode-value.ballerina punctuation.other.unicode-value.end.regexp.ballerina
+#                                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                                             ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                              ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>
+>}
+#^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina

--- a/test/resources/snapshots/regexp.bal.snap
+++ b/test/resources/snapshots/regexp.bal.snap
@@ -1,5 +1,103 @@
 // SYNTAX TEST "source.ballerina" "regexp template highlighting testcase"
-
+>
+>string str = "pattern";
+#^^^^^^ source.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#      ^ source.ballerina meta.var.expr.ballerina
+#       ^^^ source.ballerina meta.var.expr.ballerina meta.var-single-variable.expr.ballerina meta.definition.variable.ballerina variable.other.readwrite.ballerina
+#          ^ source.ballerina meta.var.expr.ballerina meta.var-single-variable.expr.ballerina
+#           ^ source.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#            ^ source.ballerina meta.var.expr.ballerina
+#             ^ source.ballerina meta.var.expr.ballerina string.quoted.double.ballerina punctuation.definition.string.begin.ballerina
+#              ^^^^^^^ source.ballerina meta.var.expr.ballerina string.quoted.double.ballerina
+#                     ^ source.ballerina meta.var.expr.ballerina string.quoted.double.ballerina punctuation.definition.string.end.ballerina
+#                      ^ source.ballerina punctuation.terminator.statement.ballerina
+>type MyRecord record {
+#^^^^ source.ballerina keyword.other.ballerina
+#    ^ source.ballerina
+#     ^^^^^^^^ source.ballerina entity.name.type.ballerina
+#             ^ source.ballerina
+#              ^^^^^^ source.ballerina meta.record.ballerina keyword.other.ballerina
+#                    ^ source.ballerina meta.record.ballerina
+#                     ^ source.ballerina meta.record.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+>   string myStr = "aaa";
+#^^^ source.ballerina meta.record.ballerina meta.block.ballerina
+#   ^^^^^^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#         ^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina
+#          ^^^^^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina meta.var-single-variable.expr.ballerina meta.definition.variable.ballerina variable.other.readwrite.ballerina
+#               ^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina meta.var-single-variable.expr.ballerina
+#                ^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                 ^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                  ^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina string.quoted.double.ballerina punctuation.definition.string.begin.ballerina
+#                   ^^^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina string.quoted.double.ballerina
+#                      ^ source.ballerina meta.record.ballerina meta.block.ballerina meta.var.expr.ballerina string.quoted.double.ballerina punctuation.definition.string.end.ballerina
+#                       ^ source.ballerina meta.record.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>};
+#^ source.ballerina meta.record.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+# ^ source.ballerina punctuation.terminator.statement.ballerina
+>
+>MyRecord rA = { myStr: "abc" };
+#^^^^^^^^ source.ballerina variable.other.readwrite.ballerina
+#        ^ source.ballerina
+#         ^^ source.ballerina variable.other.readwrite.ballerina
+#           ^ source.ballerina
+#            ^ source.ballerina keyword.operator.ballerina
+#             ^ source.ballerina
+#              ^ source.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+#               ^ source.ballerina meta.block.ballerina
+#                ^^^^^ source.ballerina meta.block.ballerina variable.other.readwrite.ballerina
+#                     ^ source.ballerina meta.block.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#                      ^ source.ballerina meta.block.ballerina meta.type.annotation.ballerina
+#                       ^ source.ballerina meta.block.ballerina meta.type.annotation.ballerina string.quoted.double.ballerina punctuation.definition.string.begin.ballerina
+#                        ^^^ source.ballerina meta.block.ballerina meta.type.annotation.ballerina string.quoted.double.ballerina
+#                           ^ source.ballerina meta.block.ballerina meta.type.annotation.ballerina string.quoted.double.ballerina punctuation.definition.string.end.ballerina
+#                            ^ source.ballerina meta.block.ballerina meta.type.annotation.ballerina
+#                             ^ source.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+#                              ^ source.ballerina punctuation.terminator.statement.ballerina
+>string:RegExp _ = re `(abc)|${str}|[abc-f\d\-]|(?i:abc)|\p{Ll}|${rA.myStr}`;
+#^^^^^^ source.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#      ^ source.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#       ^^^^^^ source.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#             ^ source.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#              ^ source.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#               ^ source.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                ^ source.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                 ^ source.ballerina meta.var.expr.ballerina
+#                  ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                    ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                     ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                      ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                       ^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                          ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                            ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
+#                             ^^^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                  ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                   ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                                    ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
+#                                      ^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina constant.other.character-class.range.regexp.ballerina
+#                                         ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.character-class.regexp.ballerina
+#                                           ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina constant.character.escape.backslash.regexp
+#                                             ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                                              ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                               ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                                ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina keyword.operator.quantifier.regexp.ballerina
+#                                                 ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina keyword.other.non-capturing-group.flags-on.regexp.ballerina
+#                                                  ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group-end.regexp.ballerina
+#                                                   ^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
+#                                                      ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                                       ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                                        ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                                          ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.begin.regexp.ballerina
+#                                                           ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina
+#                                                             ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.end.regexp.ballerina
+#                                                              ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                                               ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
+#                                                                ^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                                                   ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.character-class.regexp.ballerina
+#                                                                    ^^^^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                                                          ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                                                           ^ source.ballerina punctuation.terminator.statement.ballerina
+>
 >function name() {
 #^^^^^^^^ source.ballerina meta.function.ballerina keyword.other.ballerina
 #        ^ source.ballerina meta.function.ballerina
@@ -306,6 +404,69 @@
 #                                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
 #                                             ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
 #                                              ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `[a-z\w]`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                           ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina constant.other.character-class.range.regexp.ballerina
+#                              ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina keyword.other.character-class.regexp.ballerina
+#                                ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
 >
+>    string:RegExp _ = re `${myFunction()}`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
+#                           ^^^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                          ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
 >}
 #^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+>
+>function myFunction() retunrns string {
+#^^^^^^^^ source.ballerina meta.function.ballerina keyword.other.ballerina
+#        ^ source.ballerina meta.function.ballerina
+#         ^^^^^^^^^^ source.ballerina meta.function.ballerina meta.definition.function.ballerina entity.name.function.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.parameters.ballerina punctuation.definition.parameters.begin.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.parameters.ballerina punctuation.definition.parameters.end.ballerina
+#                     ^ source.ballerina meta.function.ballerina
+#                      ^^^^^^^^ source.ballerina meta.function.ballerina meta.definition.function.ballerina entity.name.function.ballerina
+#                              ^ source.ballerina meta.function.ballerina
+#                               ^^^^^^ source.ballerina meta.function.ballerina support.type.primitive.ballerina
+#                                     ^ source.ballerina meta.function.ballerina
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+>    return "abc";
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina keyword.control.flow.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina
+#           ^ source.ballerina meta.function.ballerina meta.block.ballerina string.quoted.double.ballerina punctuation.definition.string.begin.ballerina
+#            ^^^ source.ballerina meta.function.ballerina meta.block.ballerina string.quoted.double.ballerina
+#               ^ source.ballerina meta.function.ballerina meta.block.ballerina string.quoted.double.ballerina punctuation.definition.string.end.ballerina
+#                ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>}
+#^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+>

--- a/test/resources/snapshots/regexp.bal.snap
+++ b/test/resources/snapshots/regexp.bal.snap
@@ -69,8 +69,9 @@
 #                       ^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
 #                          ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
 #                           ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
-#                            ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
-#                             ^^^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                            ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                              ^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina variable.other.readwrite.ballerina
+#                                 ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
 #                                  ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
 #                                   ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
 #                                    ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
@@ -91,10 +92,11 @@
 #                                                           ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina
 #                                                             ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.unicode-property.regexp.ballerina punctuation.other.unicode-property.end.regexp.ballerina
 #                                                              ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
-#                                                               ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
-#                                                                ^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
-#                                                                   ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.other.character-class.regexp.ballerina
-#                                                                    ^^^^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                                               ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                                                                 ^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina variable.other.readwrite.ballerina
+#                                                                   ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina punctuation.accessor.ballerina
+#                                                                    ^^^^^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina variable.other.property.ballerina
+#                                                                         ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
 #                                                                          ^ source.ballerina meta.var.expr.ballerina regexp.template.ballerina
 #                                                                           ^ source.ballerina punctuation.terminator.statement.ballerina
 >
@@ -222,23 +224,6 @@
 #                                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
 #                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
 >
->    string:RegExp _ = re `${pattern}`;
-#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
-#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
-#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
-#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
-#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
-#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
-#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
-#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
-#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
-#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
-#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
-#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
-#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
-#                           ^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
-#                                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
-#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
 >    string:RegExp _ = re `\w\s\n`;
 #^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
 #    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
@@ -342,8 +327,9 @@
 #                           ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina
 #                              ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
 #                               ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
-#                                ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
-#                                 ^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                                  ^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina variable.other.readwrite.ballerina
+#                                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
 #                                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
 #                                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
 #                                            ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
@@ -424,6 +410,24 @@
 #                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
 #                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
 >
+>    string:RegExp _ = re `${pattern}`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                            ^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina variable.other.readwrite.ballerina
+#                                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
+#                                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
 >    string:RegExp _ = re `${myFunction()}`;
 #^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
 #    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
@@ -437,28 +441,115 @@
 #                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
 #                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
 #                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
-#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.control.assertion.regexp.ballerina
-#                           ^^^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
-#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
-#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
-#                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                          ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                            ^^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina entity.name.function.ballerina
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina meta.brace.round.block.ballerina meta.brace.round.ballerina
+#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina meta.brace.round.block.ballerina meta.brace.round.ballerina
+#                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
 #                                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
 #                                          ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `${"ABC"}`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina string.quoted.double.ballerina punctuation.definition.string.begin.ballerina
+#                             ^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina string.quoted.double.ballerina
+#                                ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina string.quoted.double.ballerina punctuation.definition.string.end.ballerina
+#                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
+#                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                   ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `(?:${pattern})`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina keyword.operator.quantifier.regexp.ballerina
+#                            ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina constant.other.flag.regexp.ballerina punctuation.other.non-capturing-group-end.regexp.ballerina
+#                             ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                               ^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina variable.other.readwrite.ballerina
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
+#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                         ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `(${myFunction()})`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                           ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.begin.ballerina
+#                             ^^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina entity.name.function.ballerina
+#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina meta.brace.round.block.ballerina meta.brace.round.ballerina
+#                                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina meta.embedded.line.ballerina meta.brace.round.block.ballerina meta.brace.round.ballerina
+#                                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina meta.template.expression.ballerina punctuation.definition.template-expression.end.ballerina
+#                                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina meta.group.assertion.regexp.ballerina punctuation.definition.group.regexp.ballerina
+#                                           ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                            ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>    string:RegExp _ = re `[(${"ABC"})]|[${"ABC"}]`;
+#^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
+#    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina support.type.primitive.ballerina
+#          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina keyword.operator.type.annotation.ballerina
+#           ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                  ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina variable.other.readwrite.ballerina
+#                   ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina meta.type.annotation.ballerina
+#                    ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina keyword.operator.assignment.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina
+#                      ^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina support.type.primitive.ballerina
+#                        ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                         ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina punctuation.definition.regexp.template.begin.ballerina
+#                          ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                           ^^^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
+#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina keyword.operator.or.regexp.ballerina
+#                                       ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.start.regexp.ballerina
+#                                        ^^^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina
+#                                                ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina constant.other.character-class.set.regexp.ballerina punctuation.definition.character-class.end.regexp.ballerina
+#                                                 ^ source.ballerina meta.function.ballerina meta.block.ballerina meta.var.expr.ballerina regexp.template.ballerina
+#                                                  ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.terminator.statement.ballerina
+>
 >}
 #^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina
 >
->function myFunction() retunrns string {
+>function myFunction() returns string {
 #^^^^^^^^ source.ballerina meta.function.ballerina keyword.other.ballerina
 #        ^ source.ballerina meta.function.ballerina
 #         ^^^^^^^^^^ source.ballerina meta.function.ballerina meta.definition.function.ballerina entity.name.function.ballerina
 #                   ^ source.ballerina meta.function.ballerina meta.parameters.ballerina punctuation.definition.parameters.begin.ballerina
 #                    ^ source.ballerina meta.function.ballerina meta.parameters.ballerina punctuation.definition.parameters.end.ballerina
-#                     ^ source.ballerina meta.function.ballerina
-#                      ^^^^^^^^ source.ballerina meta.function.ballerina meta.definition.function.ballerina entity.name.function.ballerina
-#                              ^ source.ballerina meta.function.ballerina
-#                               ^^^^^^ source.ballerina meta.function.ballerina support.type.primitive.ballerina
-#                                     ^ source.ballerina meta.function.ballerina
-#                                      ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina
+#                     ^ source.ballerina meta.function.ballerina meta.type.function.return.ballerina
+#                      ^^^^^^^ source.ballerina meta.function.ballerina meta.type.function.return.ballerina keyword.other.ballerina
+#                             ^ source.ballerina meta.function.ballerina meta.type.function.return.ballerina
+#                              ^^^^^^ source.ballerina meta.function.ballerina meta.type.function.return.ballerina support.type.primitive.ballerina
+#                                    ^ source.ballerina meta.function.ballerina meta.type.function.return.ballerina
+#                                     ^ source.ballerina meta.function.ballerina meta.block.ballerina punctuation.definition.block.ballerina
 >    return "abc";
 #^^^^ source.ballerina meta.function.ballerina meta.block.ballerina
 #    ^^^^^^ source.ballerina meta.function.ballerina meta.block.ballerina keyword.control.flow.ballerina

--- a/test/unit-test.ts
+++ b/test/unit-test.ts
@@ -205,6 +205,4 @@ describe('Unit tests', () => {
     it('regexp snapshot test', () => {
         return runTextMateTest('regexp');
     });
-
-
 });

--- a/test/unit-test.ts
+++ b/test/unit-test.ts
@@ -202,4 +202,9 @@ describe('Unit tests', () => {
         return runTextMateTest('json');
     });
 
+    it('regexp snapshot test', () => {
+        return runTextMateTest('regexp');
+    });
+
+
 });


### PR DESCRIPTION
## Purpose
$subject

Fixes: [#lang-39956](https://github.com/ballerina-platform/ballerina-lang/issues/39956)
Fixes: [#lang-39949](https://github.com/ballerina-platform/ballerina-lang/issues/39949)

## Goals

- This will color the syntaxes inside the regexp template.
- Mark/highlight the bracket bounds

## Samples
<img width="606" alt="Screenshot 2023-04-20 at 10 46 52" src="https://user-images.githubusercontent.com/46857198/233265000-c6b5989c-bc89-49d0-96ab-0b526d84b075.png">
